### PR TITLE
fix rmagick missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 RUN apt-get update -qq
-RUN apt-get -y install build-essential git openssl libreadline6 libreadline6-dev curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt-dev libmysqlclient-dev libpq-dev imagemagick libffi-dev nodejs npm nodejs-legacy mysql-client
+RUN apt-get -y install build-essential git openssl libreadline6 libreadline6-dev curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt-dev libmysqlclient-dev libpq-dev imagemagick libmagickwand-dev libffi-dev nodejs npm nodejs-legacy mysql-client
 RUN npm install -g phantomjs
 
 RUN git clone https://github.com/sstephenson/ruby-build.git /tmp/ruby-build && \


### PR DESCRIPTION
Install imagemagick dependencies in order to successfully build the rmagick gem with native extensions